### PR TITLE
spi_dma_master: fix DMA callbacks

### DIFF
--- a/series0/usart/spi_dma_master/src/main_s0_g_gg_wg_lg.c
+++ b/series0/usart/spi_dma_master/src/main_s0_g_gg_wg_lg.c
@@ -113,7 +113,7 @@ void initTransferDma(void)
   // Channel configuration for TX transmission
   DMA_CfgChannel_TypeDef channelConfigTX;
   channelConfigTX.highPri   = false;                // Set high priority for the channel
-  channelConfigTX.enableInt = false;                // Interrupt used to reset the transfer
+  channelConfigTX.enableInt = true;                 // Interrupt used to reset the transfer
   channelConfigTX.select    = DMAREQ_USART1_TXBL;   // Select DMA trigger
   channelConfigTX.cb        = &callbackTX;
   uint32_t channelNumTX     = 1;
@@ -153,7 +153,7 @@ void initReceiveDma(void)
   // Channel configuration for RX transmission
   DMA_CfgChannel_TypeDef channelConfigRX;
   channelConfigRX.highPri   = false;                    // Set high priority for the channel
-  channelConfigRX.enableInt = false;                    // Interrupt used to reset the transfer
+  channelConfigRX.enableInt = true;                     // Interrupt used to reset the transfer
   channelConfigRX.select    = DMAREQ_USART1_RXDATAV;    // Select DMA trigger
   channelConfigRX.cb        = &callbackRX;
   uint32_t channelNumRX     = 0;

--- a/series0/usart/spi_dma_master/src/main_s0_hg.c
+++ b/series0/usart/spi_dma_master/src/main_s0_hg.c
@@ -82,7 +82,7 @@ void initTransferDma(void)
   // Channel configuration for TX transmission
   DMA_CfgChannel_TypeDef channelConfigTX;
   channelConfigTX.highPri   = false;                // Set high priority for the channel
-  channelConfigTX.enableInt = false;                // Interrupt used to reset the transfer
+  channelConfigTX.enableInt = true;                 // Interrupt used to reset the transfer
   channelConfigTX.select    = DMAREQ_USART0_TXBL;   // Select DMA trigger
   channelConfigTX.cb        = &callbackTX;
   uint32_t channelNumTX     = 1;
@@ -122,7 +122,7 @@ void initReceiveDma(void)
   // Channel configuration for RX transmission
   DMA_CfgChannel_TypeDef channelConfigRX;
   channelConfigRX.highPri   = false;                    // Set high priority for the channel
-  channelConfigRX.enableInt = false;                    // Interrupt used to reset the transfer
+  channelConfigRX.enableInt = true;                     // Interrupt used to reset the transfer
   channelConfigRX.select    = DMAREQ_USART0_RXDATAV;    // Select DMA trigger
   uint32_t channelNumRX     = 0;
   DMA_CfgChannel(channelNumRX, &channelConfigRX);

--- a/series0/usart/spi_dma_master/src/main_s0_tg.c
+++ b/series0/usart/spi_dma_master/src/main_s0_tg.c
@@ -82,7 +82,7 @@ void initTransferDma(void)
   // Channel configuration for TX transmission
   DMA_CfgChannel_TypeDef channelConfigTX;
   channelConfigTX.highPri   = false;                // Set high priority for the channel
-  channelConfigTX.enableInt = false;                // Interrupt used to reset the transfer
+  channelConfigTX.enableInt = true;                 // Interrupt used to reset the transfer
   channelConfigTX.select    = DMAREQ_USART1_TXBL;   // Select DMA trigger
   channelConfigTX.cb        = &callbackTX;  	    // Callback to refresh the DMA transfer
   uint32_t channelNumTX     = 1;
@@ -122,7 +122,7 @@ void initReceiveDma(void)
   // Channel configuration for RX transmission
   DMA_CfgChannel_TypeDef channelConfigRX;
   channelConfigRX.highPri   = false;                    // Set high priority for the channel
-  channelConfigRX.enableInt = false;                    // Interrupt used to reset the transfer
+  channelConfigRX.enableInt = true;                     // Interrupt used to reset the transfer
   channelConfigRX.select    = DMAREQ_USART1_RXDATAV;    // Select DMA trigger
   channelConfigRX.cb        = &callbackRX;  	        // Callback to refresh the DMA transfer
   uint32_t channelNumRX     = 0;

--- a/series0/usart/spi_dma_master/src/main_s0_zg.c
+++ b/series0/usart/spi_dma_master/src/main_s0_zg.c
@@ -113,7 +113,7 @@ void initTransferDma(void)
   // Channel configuration for TX transmission
   DMA_CfgChannel_TypeDef channelConfigTX;
   channelConfigTX.highPri   = false;                // Set high priority for the channel
-  channelConfigTX.enableInt = false;                // Interrupt used to reset the transfer
+  channelConfigTX.enableInt = true;                 // Interrupt used to reset the transfer
   channelConfigTX.select    = DMAREQ_USART1_TXBL;   // Select DMA trigger
   channelConfigTX.cb        = &callbackTX;
   uint32_t channelNumTX     = 1;
@@ -153,7 +153,7 @@ void initReceiveDma(void)
   // Channel configuration for RX transmission
   DMA_CfgChannel_TypeDef channelConfigRX;
   channelConfigRX.highPri   = false;                    // Set high priority for the channel
-  channelConfigRX.enableInt = false;                    // Interrupt used to reset the transfer
+  channelConfigRX.enableInt = true;                     // Interrupt used to reset the transfer
   channelConfigRX.select    = DMAREQ_USART1_RXDATAV;    // Select DMA trigger
   channelConfigRX.cb        = &callbackRX;
   uint32_t channelNumRX     = 0;


### PR DESCRIPTION
The callbacks are defined but never executed because DMA interrupts are disabled. This PR enables the interrupts on the selected channels.

If the callbacks were disabled intentionally, it should have been explicitly noted in the README and in the comments.